### PR TITLE
Add delete protection and cross-region replication to the state bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,25 @@ changes to destroy the DynamoDB table.
 You can now set `force_delete` to `true` and apply the changes to re-enable
 deletion protection for other resources.
 
+## Delete protection
+
+By default (`force_delete = false`), the state bucket's policy denies
+`s3:DeleteBucket` and `s3:DeleteObjectVersion` for every principal, including
+the one running `tofu apply`/`destroy`. Plain `s3:DeleteObject` is still
+allowed — since versioning is always enabled, this only adds a delete marker
+rather than destroying data, and is required for S3 native state locking's
+lock-file release to keep working. To actually delete the bucket or purge
+old versions, set `force_delete = true` and apply first, which removes the
+deny statements (and, on the DynamoDB table, disables deletion protection).
+
+## Cross-region replication
+
+By default (`configure_cross_region_replication = true`), the module creates
+a second S3 bucket (in `us-west-2`, or `us-east-1` if the module itself is
+deployed in a `us-west-*` region) with its own KMS key, and replicates every
+object in the state bucket to it. Set `configure_cross_region_replication` to
+`false` to disable, or `replica_region` to override the destination region.
+
 ## Inputs
 
 > [!WARNING]
@@ -112,23 +131,27 @@ deletion protection for other resources.
 > If you're not currently using S3 state locking, we recommend you take the time
 > to [migrate][migrate-state-lock].
 
-| Name                     | Description                                                                                                                                                | Type     | Default | Required |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- | :------: |
-| project                  | The name of the project.                                                                                                                                   | `string` | n/a     |   yes    |
-| bucket_suffix            | Adds a random suffix to the bucket name to ensure its uniqueness.                                                                                          | `bool`   | `false` |    no    |
-| create_dynamodb_table    | Whether to create a DynamoDB table to store the Terraform state lock. If you're exclusively using [S3 state locking][s3-locking], this is safe to disable. | `bool`   | `true`  |    no    |
-| environment              | The environment for the project.                                                                                                                           | `string` | `"dev"` |    no    |
-| force_delete             | Force delete resources on destroy. This must be set to true and applied before resources can be destroyed.                                                 | `bool`   | `false` |    no    |
-| key_recovery_period      | Recovery period for deleted KMS keys in days. Must be between `7` and `30`.                                                                                | `number` | `30`    |    no    |
-| state_version_expiration | Age (in days) before non-current versions of the state file are expired.                                                                                   | `number` | `30`    |    no    |
-| tags                     | Optional tags to be applied to all resources.                                                                                                              | `list`   | `[]`    |    no    |
+| Name                               | Description                                                                                                                                                | Type     | Default | Required |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- | :------: |
+| project                            | The name of the project.                                                                                                                                   | `string` | n/a     |   yes    |
+| bucket_suffix                      | Adds a random suffix to the bucket name to ensure its uniqueness.                                                                                          | `bool`   | `false` |    no    |
+| configure_cross_region_replication | Whether to replicate the state bucket to another region for disaster recovery.                                                                             | `bool`   | `true`  |    no    |
+| create_dynamodb_table              | Whether to create a DynamoDB table to store the Terraform state lock. If you're exclusively using [S3 state locking][s3-locking], this is safe to disable. | `bool`   | `true`  |    no    |
+| environment                        | The environment for the project.                                                                                                                           | `string` | `"dev"` |    no    |
+| force_delete                       | Force delete resources on destroy. This must be set to true and applied before resources can be destroyed.                                                 | `bool`   | `false` |    no    |
+| key_recovery_period                | Recovery period for deleted KMS keys in days. Must be between `7` and `30`.                                                                                | `number` | `30`    |    no    |
+| replica_region                     | Region to replicate the state bucket to. Defaults to `us-west-2` (or `us-east-1` if deployed in a `us-west-*` region).                                     | `string` | `null`  |    no    |
+| state_version_expiration           | Age (in days) before non-current versions of the state file are expired.                                                                                   | `number` | `30`    |    no    |
+| tags                               | Optional tags to be applied to all resources.                                                                                                              | `list`   | `[]`    |    no    |
 
 ## Outputs
 
-| Name    | Description                              | Type     |
-| ------- | ---------------------------------------- | -------- |
-| bucket  | Name of the S3 bucket for state storage. | `string` |
-| kms_key | KMS key used to encrypt state.           | `string` |
+| Name           | Description                                                                        | Type     |
+| -------------- | ----------------------------------------------------------------------------------- | -------- |
+| bucket         | Name of the S3 bucket for state storage.                                            | `string` |
+| kms_key        | KMS key used to encrypt state.                                                       | `string` |
+| replica_bucket | Name of the replica S3 bucket for state storage, if cross-region replication is enabled. | `string` |
+| replica_kms_key| KMS key used to encrypt the replica state bucket, if cross-region replication is enabled. | `string` |
 
 [badge-checks]: https://github.com/codeforamerica/tofu-modules-aws-backend/actions/workflows/main.yaml/badge.svg
 [badge-release]: https://img.shields.io/github/v/release/codeforamerica/tofu-modules-aws-backend?logo=github&label=Latest%20Release

--- a/README.md
+++ b/README.md
@@ -120,6 +120,55 @@ deployed in a `us-west-*` region) with its own KMS key, and replicates every
 object in the state bucket to it. Set `configure_cross_region_replication` to
 `false` to disable, or `replica_region` to override the destination region.
 
+## Rebuilding after state loss
+
+If this module's own OpenTofu state is lost or corrupted but the underlying
+AWS resources still exist, rebuild management via `tofu import` instead of
+recreating everything from scratch. Bucket/alias/table names are derived
+from `project`/`environment` (see [Usage](#usage)); use `aws s3api
+list-buckets`, `aws kms list-aliases`, etc. to confirm the real names if
+unsure.
+
+```bash
+tofu import aws_s3_bucket.tfstate <bucket-name>
+tofu import aws_s3_bucket_public_access_block.tfstate <bucket-name>
+tofu import aws_s3_bucket_server_side_encryption_configuration.tfstate <bucket-name>
+tofu import aws_s3_bucket_versioning.tfstate <bucket-name>
+tofu import aws_s3_bucket_logging.tfstate <bucket-name>
+tofu import aws_s3_bucket_policy.tfstate <bucket-name>
+tofu import aws_s3_bucket_lifecycle_configuration.tfstate <bucket-name>
+tofu import aws_kms_key.backend <key-id>
+tofu import aws_kms_alias.backend "alias/<project>/<environment>/backend"
+# Only if create_dynamodb_table = true:
+tofu import 'aws_dynamodb_table.tfstate_lock["this"]' <environment>.tfstate
+```
+
+If `configure_cross_region_replication = true`, also import the replica-side
+resources, against the bucket/key/role in `replica_region`:
+
+```bash
+tofu import 'aws_s3_bucket.tfstate_replica["this"]' <replica-bucket-name>
+tofu import 'aws_s3_bucket_public_access_block.tfstate_replica["this"]' <replica-bucket-name>
+tofu import 'aws_s3_bucket_server_side_encryption_configuration.tfstate_replica["this"]' <replica-bucket-name>
+tofu import 'aws_s3_bucket_versioning.tfstate_replica["this"]' <replica-bucket-name>
+tofu import 'aws_s3_bucket_logging.tfstate_replica["this"]' <replica-bucket-name>
+tofu import 'aws_s3_bucket_policy.tfstate_replica["this"]' <replica-bucket-name>
+tofu import 'aws_s3_bucket_lifecycle_configuration.tfstate_replica["this"]' <replica-bucket-name>
+tofu import 'aws_kms_key.backend_replica["this"]' <replica-key-id>
+tofu import 'aws_kms_alias.backend_replica["this"]' "alias/<project>/<environment>/backend-replica"
+tofu import 'aws_iam_role.replication["this"]' <project>-<environment>-tfstate-replication
+tofu import 'aws_iam_role_policy.replication["this"]' <project>-<environment>-tfstate-replication:<project>-<environment>-tfstate-replication
+tofu import 'aws_s3_bucket_replication_configuration.tfstate["this"]' <bucket-name>
+```
+
+After importing every resource, run `tofu plan` and confirm it reports no
+changes — a non-empty diff means an import target or ID was wrong, not that
+real infrastructure needs to change.
+
+If the AWS resources themselves were destroyed (not just the state), skip
+this section and follow the normal [Usage](#usage) steps instead — there's
+nothing to import, only to recreate.
+
 ## Inputs
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -117,8 +117,71 @@ deny statements (and, on the DynamoDB table, disables deletion protection).
 By default (`configure_cross_region_replication = true`), the module creates
 a second S3 bucket (in `us-west-2`, or `us-east-1` if the module itself is
 deployed in a `us-west-*` region) with its own KMS key, and replicates every
-object in the state bucket to it. Set `configure_cross_region_replication` to
-`false` to disable, or `replica_region` to override the destination region.
+object written to the state bucket **after replication is enabled** to it.
+Set `configure_cross_region_replication` to `false` to disable, or
+`replica_region` to override the destination region. If your primary region
+isn't in the US, the `us-west-2`/`us-east-1` default doesn't apply to you —
+set `replica_region` explicitly.
+
+The replica is a backstop, not a mirror: delete markers are **not**
+replicated, so deleting an object in the primary bucket doesn't delete it in
+the replica too. The replica bucket also has [Object Lock][s3-object-lock]
+enabled (`GOVERNANCE` mode, 35-day default retention) — this can only be
+turned on at bucket creation, so it's applied to the replica but not the
+(already-existing, for current consumers) primary bucket.
+
+`GOVERNANCE` mode stops anyone without the `s3:BypassGovernanceRetention`
+permission from deleting or shortening retention on an object for 35 days —
+including someone who's just removed the bucket policy. Unlike `COMPLIANCE`,
+it's still possible to delete a locked object if absolutely necessary, for
+someone with that permission. Note that OpenTofu's own `force_delete` /
+`force_destroy` may not automatically send the bypass on your behalf during
+`tofu destroy` — that's one of the things the live verification test is
+meant to confirm before this merges.
+
+Live replication only covers objects written after the config is applied —
+**existing objects in the bucket are not backfilled automatically.** When
+enabling this on a bucket that already has state files in it, run a one-time
+[S3 Batch Replication][s3-batch-replication] job to backfill them:
+
+```bash
+aws s3control create-job \
+  --account-id <account-id> \
+  --operation '{"S3ReplicateObject": {}}' \
+  --manifest-generator '{"S3JobManifestGenerator": {
+    "sourceBucket": "arn:aws:s3:::<bucket-name>",
+    "enableManifestOutput": false
+  }}' \
+  --priority 1 \
+  --role-arn <replication-role-arn> \
+  --report '{"Enabled": false}' \
+  --confirmation-required
+```
+
+Use the `replication` output's IAM role ARN, confirm the job in the S3
+console, then run it for real once the manifest looks right.
+
+## Recovering from a regional outage
+
+If the *primary region* (not just the bucket) is unavailable, the fix is
+different from [state loss](#rebuilding-after-state-loss): the replica
+bucket already has the data, you just need to point OpenTofu at it.
+
+1. Confirm the primary region is actually down, not just the one bucket —
+   if only the bucket is gone, use the import path above instead.
+2. In every *consumer* config (not this module itself), update the
+   `backend "s3"` block to point `bucket`/`region` at the replica values,
+   keeping the same `key`. Do this everywhere before applying anything
+   else — a consumer left pointed at the dead primary will fail to
+   lock/read state.
+3. Run `tofu init -reconfigure` against the replica backend and confirm
+   `tofu plan` shows no unexpected diff.
+4. Once the primary region recovers, decide whether to fail back (re-point
+   at the primary and let replication resume) or promote the replica
+   permanently — the latter needs a new replica target in a third region to
+   restore redundancy, and is a bigger decision than this module covers.
+5. Rolling back this procedure (primary recovers before you've cut over)
+   is just: don't change the backend block. No changes were destructive.
 
 ## Rebuilding after state loss
 
@@ -144,18 +207,23 @@ tofu import 'aws_dynamodb_table.tfstate_lock["this"]' <environment>.tfstate
 ```
 
 If `configure_cross_region_replication = true`, also import the replica-side
-resources, against the bucket/key/role in `replica_region`:
+resources, against the bucket/key/role in `replica_region`. Resources with a
+`region` argument need `@<replica-region>` appended to the import ID (AWS
+provider's [enhanced region support][enhanced-region-support]); IAM is
+global and the replication config lives on the primary bucket, so neither
+needs the suffix:
 
 ```bash
-tofu import 'aws_s3_bucket.tfstate_replica["this"]' <replica-bucket-name>
-tofu import 'aws_s3_bucket_public_access_block.tfstate_replica["this"]' <replica-bucket-name>
-tofu import 'aws_s3_bucket_server_side_encryption_configuration.tfstate_replica["this"]' <replica-bucket-name>
-tofu import 'aws_s3_bucket_versioning.tfstate_replica["this"]' <replica-bucket-name>
-tofu import 'aws_s3_bucket_logging.tfstate_replica["this"]' <replica-bucket-name>
-tofu import 'aws_s3_bucket_policy.tfstate_replica["this"]' <replica-bucket-name>
-tofu import 'aws_s3_bucket_lifecycle_configuration.tfstate_replica["this"]' <replica-bucket-name>
-tofu import 'aws_kms_key.backend_replica["this"]' <replica-key-id>
-tofu import 'aws_kms_alias.backend_replica["this"]' "alias/<project>/<environment>/backend-replica"
+tofu import 'aws_s3_bucket.tfstate_replica["this"]' <replica-bucket-name>@<replica-region>
+tofu import 'aws_s3_bucket_public_access_block.tfstate_replica["this"]' <replica-bucket-name>@<replica-region>
+tofu import 'aws_s3_bucket_server_side_encryption_configuration.tfstate_replica["this"]' <replica-bucket-name>@<replica-region>
+tofu import 'aws_s3_bucket_versioning.tfstate_replica["this"]' <replica-bucket-name>@<replica-region>
+tofu import 'aws_s3_bucket_logging.tfstate_replica["this"]' <replica-bucket-name>@<replica-region>
+tofu import 'aws_s3_bucket_policy.tfstate_replica["this"]' <replica-bucket-name>@<replica-region>
+tofu import 'aws_s3_bucket_lifecycle_configuration.tfstate_replica["this"]' <replica-bucket-name>@<replica-region>
+tofu import 'aws_s3_bucket_object_lock_configuration.tfstate_replica["this"]' <replica-bucket-name>@<replica-region>
+tofu import 'aws_kms_key.backend_replica["this"]' <replica-key-id>@<replica-region>
+tofu import 'aws_kms_alias.backend_replica["this"]' alias/<project>/<environment>/backend-replica@<replica-region>
 tofu import 'aws_iam_role.replication["this"]' <project>-<environment>-tfstate-replication
 tofu import 'aws_iam_role_policy.replication["this"]' <project>-<environment>-tfstate-replication:<project>-<environment>-tfstate-replication
 tofu import 'aws_s3_bucket_replication_configuration.tfstate["this"]' <bucket-name>
@@ -190,7 +258,7 @@ nothing to import, only to recreate.
 | force_delete                       | Force delete resources on destroy. This must be set to true and applied before resources can be destroyed.                                                 | `bool`   | `false` |    no    |
 | key_recovery_period                | Recovery period for deleted KMS keys in days. Must be between `7` and `30`.                                                                                | `number` | `30`    |    no    |
 | replica_region                     | Region to replicate the state bucket to. Defaults to `us-west-2` (or `us-east-1` if deployed in a `us-west-*` region).                                     | `string` | `null`  |    no    |
-| state_version_expiration           | Age (in days) before non-current versions of the state file are expired.                                                                                   | `number` | `30`    |    no    |
+| state_version_expiration           | Age (in days) before non-current versions of the state file are expired.                                                                                   | `number` | `180`   |    no    |
 | tags                               | Optional tags to be applied to all resources.                                                                                                              | `list`   | `[]`    |    no    |
 
 ## Outputs
@@ -208,4 +276,7 @@ nothing to import, only to recreate.
 [latest-release]: https://github.com/codeforamerica/tofu-modules-aws-backend/releases/latest
 [migrate-state-lock]: #migrating-from-dynamodb-to-s3-state-locking
 [s3-locking]: https://opentofu.org/docs/language/settings/backends/s3/#s3-state-locking
+[s3-object-lock]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-overview.html
+[s3-batch-replication]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-batch.html
+[enhanced-region-support]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support
 [s3-locking-migrate]: https://opentofu.org/docs/language/settings/backends/s3/#migrating-from-dynamodb-to-s3-locking

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ resource "aws_kms_key" "backend" {
     account_id : data.aws_caller_identity.identity.account_id,
     partition : data.aws_partition.current.partition,
     bucket_arn : aws_s3_bucket.tfstate.arn
+    deny_delete : !var.force_delete
   })
 
   tags = merge({ use = "infrastructure-state" }, var.tags)
@@ -42,6 +43,7 @@ resource "aws_kms_key" "backend_replica" {
     account_id : data.aws_caller_identity.identity.account_id,
     partition : data.aws_partition.current.partition,
     bucket_arn : aws_s3_bucket.tfstate_replica["this"].arn
+    deny_delete : !var.force_delete
   })
 
   tags = merge({ use = "infrastructure-state" }, var.tags)

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,17 @@
 locals {
   aws_logs_path = "/AWSLogs/${data.aws_caller_identity.identity.account_id}"
   prefix        = "${var.project}-${var.environment}"
+
+  # Defaults the replica to us-west-2, or us-east-1 if already deployed in a
+  # us-west region, matching the org's standard primary/replica region pairing.
+  effective_replica_region = coalesce(var.replica_region, startswith(data.aws_region.current.region, "us-west") ? "us-east-1" : "us-west-2")
 }
 
 data "aws_caller_identity" "identity" {}
 
 data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
 
 resource "aws_kms_key" "backend" {
   description             = "OpenTofu backend encryption key for ${var.project} ${var.environment}"
@@ -23,6 +29,30 @@ resource "aws_kms_key" "backend" {
 resource "aws_kms_alias" "backend" {
   name          = "alias/${var.project}/${var.environment}/backend"
   target_key_id = aws_kms_key.backend.id
+}
+
+resource "aws_kms_key" "backend_replica" {
+  for_each = var.configure_cross_region_replication ? toset(["this"]) : toset([])
+
+  region                  = local.effective_replica_region
+  description             = "OpenTofu backend replica encryption key for ${var.project} ${var.environment}"
+  deletion_window_in_days = var.key_recovery_period
+  enable_key_rotation     = true
+  policy = templatefile("${path.module}/templates/key-policy.json.tftpl", {
+    account_id : data.aws_caller_identity.identity.account_id,
+    partition : data.aws_partition.current.partition,
+    bucket_arn : aws_s3_bucket.tfstate_replica["this"].arn
+  })
+
+  tags = merge({ use = "infrastructure-state" }, var.tags)
+}
+
+resource "aws_kms_alias" "backend_replica" {
+  for_each = var.configure_cross_region_replication ? toset(["this"]) : toset([])
+
+  region        = local.effective_replica_region
+  name          = "alias/${var.project}/${var.environment}/backend-replica"
+  target_key_id = aws_kms_key.backend_replica["this"].id
 }
 
 resource "aws_dynamodb_table" "tfstate_lock" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,13 @@ output "kms_key" {
   value       = aws_kms_key.backend.id
   description = "The KMS key used to encrypt the Terraform state."
 }
+
+output "replica_bucket" {
+  value       = try(aws_s3_bucket.tfstate_replica["this"].id, null)
+  description = "The replica S3 bucket used for cross-region state replication, if enabled."
+}
+
+output "replica_kms_key" {
+  value       = try(aws_kms_key.backend_replica["this"].id, null)
+  description = "The KMS key used to encrypt the replica state bucket, if cross-region replication is enabled."
+}

--- a/s3.tf
+++ b/s3.tf
@@ -83,7 +83,32 @@ resource "aws_s3_bucket" "tfstate_replica" {
   bucket_prefix = var.bucket_suffix ? "${local.prefix}-tfstate-replica-" : null
   force_destroy = var.force_delete
 
+  # Object Lock can only be enabled at bucket creation, so this is the one
+  # chance to have it on the replica. A bucket-policy deny only stops
+  # someone without PutBucketPolicy access; Object Lock backs that up.
+  object_lock_enabled = true
+
   tags = merge({ use = "infrastructure-state" }, var.tags)
+}
+
+resource "aws_s3_bucket_object_lock_configuration" "tfstate_replica" {
+  for_each = var.configure_cross_region_replication ? toset(["this"]) : toset([])
+
+  depends_on = [aws_s3_bucket_versioning.tfstate_replica]
+
+  region = local.effective_replica_region
+  bucket = aws_s3_bucket.tfstate_replica["this"].id
+
+  rule {
+    default_retention {
+      # GOVERNANCE, not COMPLIANCE: a principal with s3:BypassGovernanceRetention
+      # can still delete/shorten this if absolutely needed. Still stops anyone
+      # without that permission, including someone who's just removed the
+      # bucket policy.
+      mode = "GOVERNANCE"
+      days = 35
+    }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "tfstate_replica" {
@@ -213,7 +238,7 @@ resource "aws_iam_role_policy" "replication" {
       },
       {
         Effect   = "Allow"
-        Action   = ["s3:ReplicateObject", "s3:ReplicateDelete", "s3:ReplicateTags"]
+        Action   = ["s3:ReplicateObject", "s3:ReplicateTags"]
         Resource = ["${aws_s3_bucket.tfstate_replica["this"].arn}/*"]
       },
       {
@@ -228,7 +253,7 @@ resource "aws_iam_role_policy" "replication" {
       },
       {
         Effect   = "Allow"
-        Action   = ["kms:Encrypt"]
+        Action   = ["kms:Encrypt", "kms:Decrypt", "kms:GenerateDataKey*"]
         Resource = [aws_kms_key.backend_replica["this"].arn]
         Condition = {
           StringLike = {
@@ -258,8 +283,13 @@ resource "aws_s3_bucket_replication_configuration" "tfstate" {
 
     filter {}
 
+    # Deliberately not replicating delete markers: the replica is meant to
+    # be a backstop, not a mirror. Plain DeleteObject (needed for S3 native
+    # state locking's lock-file release) creates a delete marker; letting
+    # that replicate would hide the object in both copies at once, and the
+    # replica's own lifecycle rule would eventually purge the real version.
     delete_marker_replication {
-      status = "Enabled"
+      status = "Disabled"
     }
 
     source_selection_criteria {

--- a/s3.tf
+++ b/s3.tf
@@ -48,6 +48,7 @@ resource "aws_s3_bucket_policy" "tfstate" {
     account : data.aws_caller_identity.identity.account_id
     partition : data.aws_partition.current.partition
     bucket : aws_s3_bucket.tfstate.bucket
+    deny_delete : !var.force_delete
   })
 }
 
@@ -68,6 +69,212 @@ resource "aws_s3_bucket_lifecycle_configuration" "tfstate" {
 
     noncurrent_version_expiration {
       noncurrent_days = var.state_version_expiration
+    }
+  }
+}
+
+# --- Cross-region replication of the state bucket ---
+
+resource "aws_s3_bucket" "tfstate_replica" {
+  for_each = var.configure_cross_region_replication ? toset(["this"]) : toset([])
+
+  region        = local.effective_replica_region
+  bucket        = var.bucket_suffix ? null : "${local.prefix}-tfstate-replica"
+  bucket_prefix = var.bucket_suffix ? "${local.prefix}-tfstate-replica-" : null
+  force_destroy = var.force_delete
+
+  tags = merge({ use = "infrastructure-state" }, var.tags)
+}
+
+resource "aws_s3_bucket_public_access_block" "tfstate_replica" {
+  for_each = var.configure_cross_region_replication ? toset(["this"]) : toset([])
+
+  region = local.effective_replica_region
+  bucket = aws_s3_bucket.tfstate_replica["this"].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tfstate_replica" {
+  for_each = var.configure_cross_region_replication ? toset(["this"]) : toset([])
+
+  region = local.effective_replica_region
+  bucket = aws_s3_bucket.tfstate_replica["this"].id
+
+  rule {
+    bucket_key_enabled = true
+
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.backend_replica["this"].arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "tfstate_replica" {
+  for_each = var.configure_cross_region_replication ? toset(["this"]) : toset([])
+
+  region = local.effective_replica_region
+  bucket = aws_s3_bucket.tfstate_replica["this"].id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_logging" "tfstate_replica" {
+  for_each = var.configure_cross_region_replication ? toset(["this"]) : toset([])
+
+  region        = local.effective_replica_region
+  bucket        = aws_s3_bucket.tfstate_replica["this"].id
+  target_bucket = aws_s3_bucket.tfstate_replica["this"].id
+  target_prefix = "${local.aws_logs_path}/s3accesslogs/${aws_s3_bucket.tfstate_replica["this"].id}"
+}
+
+resource "aws_s3_bucket_policy" "tfstate_replica" {
+  for_each = var.configure_cross_region_replication ? toset(["this"]) : toset([])
+
+  region = local.effective_replica_region
+  bucket = aws_s3_bucket.tfstate_replica["this"].id
+  policy = templatefile("${path.module}/templates/bucket-policy.json.tftpl", {
+    account : data.aws_caller_identity.identity.account_id
+    partition : data.aws_partition.current.partition
+    bucket : aws_s3_bucket.tfstate_replica["this"].bucket
+    deny_delete : !var.force_delete
+  })
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "tfstate_replica" {
+  for_each = var.configure_cross_region_replication ? toset(["this"]) : toset([])
+
+  region = local.effective_replica_region
+  bucket = aws_s3_bucket.tfstate_replica["this"].id
+
+  rule {
+    id     = "state"
+    status = "Enabled"
+
+    filter {
+      prefix = ""
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = var.state_version_expiration
+    }
+  }
+}
+
+resource "aws_iam_role" "replication" {
+  for_each = var.configure_cross_region_replication ? toset(["this"]) : toset([])
+
+  name = "${local.prefix}-tfstate-replication"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "s3.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = merge({ use = "infrastructure-state" }, var.tags)
+}
+
+resource "aws_iam_role_policy" "replication" {
+  for_each = var.configure_cross_region_replication ? toset(["this"]) : toset([])
+
+  name = "${local.prefix}-tfstate-replication"
+  role = aws_iam_role.replication["this"].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetReplicationConfiguration", "s3:ListBucket"]
+        Resource = [aws_s3_bucket.tfstate.arn]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObjectVersionForReplication",
+          "s3:GetObjectVersionAcl",
+          "s3:GetObjectVersionTagging",
+        ]
+        Resource = ["${aws_s3_bucket.tfstate.arn}/*"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ReplicateObject", "s3:ReplicateDelete", "s3:ReplicateTags"]
+        Resource = ["${aws_s3_bucket.tfstate_replica["this"].arn}/*"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt"]
+        Resource = [aws_kms_key.backend.arn]
+        Condition = {
+          StringLike = {
+            "kms:ViaService" = "s3.${data.aws_region.current.region}.amazonaws.com"
+          }
+        }
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["kms:Encrypt"]
+        Resource = [aws_kms_key.backend_replica["this"].arn]
+        Condition = {
+          StringLike = {
+            "kms:ViaService" = "s3.${local.effective_replica_region}.amazonaws.com"
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_s3_bucket_replication_configuration" "tfstate" {
+  for_each = var.configure_cross_region_replication ? toset(["this"]) : toset([])
+
+  # Versioning must be enabled on both buckets before replication can be configured.
+  depends_on = [
+    aws_s3_bucket_versioning.tfstate,
+    aws_s3_bucket_versioning.tfstate_replica,
+  ]
+
+  bucket = aws_s3_bucket.tfstate.id
+  role   = aws_iam_role.replication["this"].arn
+
+  rule {
+    id     = "state-replication"
+    status = "Enabled"
+
+    filter {}
+
+    delete_marker_replication {
+      status = "Enabled"
+    }
+
+    source_selection_criteria {
+      sse_kms_encrypted_objects {
+        status = "Enabled"
+      }
+    }
+
+    destination {
+      bucket        = aws_s3_bucket.tfstate_replica["this"].arn
+      storage_class = "STANDARD"
+
+      encryption_configuration {
+        replica_kms_key_id = aws_kms_key.backend_replica["this"].arn
+      }
     }
   }
 }

--- a/templates/bucket-policy.json.tftpl
+++ b/templates/bucket-policy.json.tftpl
@@ -17,6 +17,19 @@
                     "aws:SecureTransport": false
                 }
             }
-        }
+        }%{ if deny_delete },
+        {
+            "Sid": "DenyPermanentStateDeletion",
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": [
+                "s3:DeleteBucket",
+                "s3:DeleteObjectVersion"
+            ],
+            "Resource": [
+                "arn:${partition}:s3:::${bucket}",
+                "arn:${partition}:s3:::${bucket}/*"
+            ]
+        }%{ endif }
     ]
 }

--- a/templates/key-policy.json.tftpl
+++ b/templates/key-policy.json.tftpl
@@ -33,6 +33,16 @@
             ]
         }
       }
-    }
+    }%{ if deny_delete },
+    {
+      "Sid": "DenyKeyDeletion",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": [
+          "kms:ScheduleKeyDeletion",
+          "kms:DisableKey"
+      ],
+      "Resource": "*"
+    }%{ endif }
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,15 @@ variable "bucket_suffix" {
   default     = false
 }
 
+variable "configure_cross_region_replication" {
+  type        = bool
+  description = <<-EOT
+    Whether to replicate the state bucket to another region for disaster
+    recovery. Enabled by default; set to `false` to disable.
+    EOT
+  default     = true
+}
+
 variable "create_dynamodb_table" {
   type        = bool
   description = <<-EOT
@@ -47,6 +56,16 @@ variable "key_recovery_period" {
 variable "project" {
   type        = string
   description = "Project that these resources are supporting."
+}
+
+variable "replica_region" {
+  type        = string
+  description = <<-EOT
+    Region to replicate the state bucket to. If not specified, defaults to
+    `us-west-2`, or `us-east-1` if the module is deployed in a `us-west-*`
+    region. Only used if `configure_cross_region_replication` is `true`.
+    EOT
+  default     = null
 }
 
 variable "state_version_expiration" {

--- a/variables.tf
+++ b/variables.tf
@@ -73,7 +73,7 @@ variable "state_version_expiration" {
   description = <<-EOT
     Age (in days) before non-current versions of the state file are expired.
     EOT
-  default     = 30
+  default     = 180
 }
 
 variable "tags" {


### PR DESCRIPTION
- Deny bucket/version deletion on the state bucket by default (toggled via `force_delete`), matching CFA-PROC-019A §5.1.
- Add an optional, default-on cross-region replica bucket (its own KMS key, mirrors the primary bucket's encryption/versioning/logging/lifecycle/policy).
- Document an import-based rebuild path for reattaching OpenTofu to the state bucket (and its replica) if state is ever lost but the real resources survive.